### PR TITLE
refactor: Decouple block control logic from InputController

### DIFF
--- a/Assets/Scripts/InputController.cs
+++ b/Assets/Scripts/InputController.cs
@@ -5,7 +5,7 @@ public class InputController : MonoBehaviour
 {
     void Update()
     {
-        // UI ¿ä¼Ò°¡ ¾Æ´Ñ °ÔÀÓ ¿ÀºêÁ§Æ®¿¡ ´ëÇÑ ÅÍÄ¡¸¸ Ã³¸®
+        // UI ìš”ì†Œê°€ ì•„ë‹Œ ê²Œìž„ ì˜¤ë¸Œì íŠ¸ì— ëŒ€í•œ í„°ì¹˜ë§Œ ì²˜ë¦¬
         if (Input.touchCount > 0 && !EventSystem.current.IsPointerOverGameObject(Input.GetTouch(0).fingerId))
         {
             Touch touch = Input.GetTouch(0);
@@ -13,7 +13,7 @@ public class InputController : MonoBehaviour
             if (touch.phase == TouchPhase.Began)
             {
                 Debug.Log("Touch Screen");
-                FindObjectOfType<BlockSpawner>().CurrentBlock.GetComponent<BlockCollision>()?.FixBlock();
+                InputEvents.InvokeOnTouch();
             }
         }
     }

--- a/Assets/Scripts/InputEvents.cs
+++ b/Assets/Scripts/InputEvents.cs
@@ -1,0 +1,12 @@
+using System;
+using UnityEngine;
+
+public class InputEvents : MonoBehaviour
+{
+    public static event Action OnTouch;
+
+    public static void InvokeOnTouch()
+    {
+        OnTouch?.Invoke();
+    }
+}

--- a/Assets/Scripts/InputEvents.cs.meta
+++ b/Assets/Scripts/InputEvents.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 95f3fd56c4258444690a88341d95b3ff
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This commit removes the block control logic from `InputController` and prepares for its future implementation in a dedicated `BlockController`.

- Removed the code responsible for fixing the block from `InputController`.
- Added `InputEvents.cs` to define a static `OnTouch` event.
- Modified `InputController.cs` to invoke the `OnTouch` event when a touch is detected.