### PR TITLE
feat: Add block count variable and refactor block creation logic

### DIFF
--- a/Assets/Scripts/BlockSpawner.cs
+++ b/Assets/Scripts/BlockSpawner.cs
@@ -2,9 +2,10 @@ using UnityEngine;
 
 public class BlockSpawner : MonoBehaviour
 {
+    public int _blockCount = 0; // 생성된 블록 개수를 저장하는 변수
     [SerializeField] private GameObject blockPrefab;
-    [SerializeField] private GameObject currentBlock;
-    [SerializeField] private GameObject prevBlock;
+    [SerializeField] private GameObject currentBlock; // 현재 움직이는 블록
+    [SerializeField] private GameObject prevBlock; // 이전에 생성된 블록
 
     public GameObject CurrentBlock { get => currentBlock; }
     public GameObject PrevBlock { get => prevBlock; }
@@ -15,18 +16,25 @@ public class BlockSpawner : MonoBehaviour
 
         GameObject block = Instantiate(blockPrefab, transform.position, Quaternion.identity);
         block.name = "currentBlock";
-        
-        if(currentBlock == null)
+
+        if (_blockCount == 0) // 첫번째 블록 생성 시
         {
-            currentBlock = block;
-            currentBlock.GetComponent<Collider>().isTrigger = false;
+            prevBlock = block;
+            prevBlock.GetComponent<Collider>().isTrigger = false;
+            prevBlock.name = "prevBlock";
         }
-        else
+        else // 두 번째 블록부터 생성 시
         {
-            currentBlock.name = "prevBlock";
-            prevBlock = currentBlock;
-            block.AddComponent<BlockCollision>();
-            currentBlock = block;
+            if(currentBlock != null) // 이미 생성된 블록이 있는 경우
+            {
+                prevBlock = currentBlock; // 현재 블록을 이전 블록으로 설정
+                prevBlock.name = "prevBlock";
+            }
+
+            block.AddComponent<BlockCollision>(); // 새 블록에 BlockCollision 컴포넌트 추가
+            currentBlock = block; // 새 블록을 현재 블록으로 설정
         }
+
+        _blockCount++;
     }
 }


### PR DESCRIPTION
This commit introduces a new variable `_blockCount` to track the number of created blocks. It also refactors the block creation logic to simplify the code and improve readability.

- Added a new variable `_blockCount` to keep track of the number of created blocks.
- Removed the unnecessary check for `currentBlock == null` in the `SpawnNewBlock()` method.
- Moved the initialization of `prevBlock` and the setting of its `isTrigger` property to the `_blockCount == 0` block.
- Simplified the logic for updating `prevBlock` and `currentBlock` in the `_blockCount > 0` block.

This commit improves the code's clarity and efficiency.